### PR TITLE
Fix ISO triple fault by adding load of our own GDT

### DIFF
--- a/src/core/lowlevel.asm
+++ b/src/core/lowlevel.asm
@@ -47,6 +47,7 @@ load_gdt:
     mov es, eax
     mov fs, eax
     mov gs, eax
+    mov ss, eax
     ret
 
 keyboard_handler_int:

--- a/src/core/lowlevel.asm
+++ b/src/core/lowlevel.asm
@@ -2,8 +2,52 @@ section .text
 
 global keyboard_handler_int
 global load_idt
-
+global load_gdt
 extern keyboard_handler
+
+; GDT with a NULL Descriptor, a 32-Bit code Descriptor
+; and a 32-bit Data Descriptor
+gdt_start:
+gdt_null:
+    dd 0x0
+    dd 0x0
+
+gdt_code:
+    dw 0xffff
+    dw 0x0
+    db 0x0
+    db 10011010b
+    db 11001111b
+    db 0x0
+
+gdt_data:
+    dw 0xffff
+    dw 0x0
+    db 0x0
+    db 10010010b
+    db 11001111b
+    db 0x0
+gdt_end:
+
+; GDT descroptor record
+gdt_descriptor:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
+
+CODE_SEG equ gdt_code - gdt_start
+DATA_SEG equ gdt_data - gdt_start
+
+; Load GDT and set selectors for a flat memory model
+load_gdt:
+    lgdt [gdt_descriptor]
+    jmp CODE_SEG:.setcs              ; Set CS seelctor with far JMP
+.setcs:
+    mov eax, DATA_SEG                ; Set the Data selectors to defaults
+    mov ds, eax
+    mov es, eax
+    mov fs, eax
+    mov gs, eax
+    ret
 
 keyboard_handler_int:
     pushad

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -17,10 +17,12 @@ void dev_init(void);
 
 void interrupts_init(void);
 void shell_init(void);
+void load_gdt(void);
 
 void kernel_main(void)
 {
 	// Initialize basic components
+    load_gdt();
 	term_init();
 	mem_init();
 	dev_init();


### PR DESCRIPTION
The crash when using _GRUB_ rather than _QEMU's_ `-kernel` is related to part of the [multiboot specification](https://www.gnu.org/software/grub/manual/multiboot/multiboot.html):

> ‘GDTR’
Even though the segment registers are set up as described above, the ‘GDTR’ may be invalid, so the OS image must not load any segment registers (even just reloading the same values!) until it sets up its own ‘GDT’. 

This pull request is a quick hack that introduces a new `load_gdt` function that setups up a _GDT_ and updates the code and data selector. The reason for the triple fault is because an interrupt will set the CS selector. If there is an invalid _GDTR_ the interrupt handler will fault and the machine reboots.