### PR TITLE
Enable cursor set cursor shape

### DIFF
--- a/sh/build.sh
+++ b/sh/build.sh
@@ -6,8 +6,10 @@ ${BASH_SOURCE%/*}/clean.sh
 ${BASH_SOURCE%/*}/prepdir.sh
 
 COMMON_RUN="${BASH_SOURCE%/*}/../crosscompiler/bin"
-GCC_RUN="$COMMON_RUN/i686-elf-gcc"
-GPP_RUN="$COMMON_RUN/i686-elf-g++"
+#GCC_RUN="$COMMON_RUN/i686-elf-gcc"
+#GPP_RUN="$COMMON_RUN/i686-elf-g++"
+GCC_RUN="i686-elf-gcc"
+GPP_RUN="i686-elf-g++"
 
 COMMON_PARAMS="-ffreestanding -O2 -Wall -Wextra -D DEBUG"
 GCC_PARAMS="-std=gnu99 $COMMON_PARAMS"

--- a/sh/build.sh
+++ b/sh/build.sh
@@ -6,10 +6,8 @@ ${BASH_SOURCE%/*}/clean.sh
 ${BASH_SOURCE%/*}/prepdir.sh
 
 COMMON_RUN="${BASH_SOURCE%/*}/../crosscompiler/bin"
-#GCC_RUN="$COMMON_RUN/i686-elf-gcc"
-#GPP_RUN="$COMMON_RUN/i686-elf-g++"
-GCC_RUN="i686-elf-gcc"
-GPP_RUN="i686-elf-g++"
+GCC_RUN="$COMMON_RUN/i686-elf-gcc"
+GPP_RUN="$COMMON_RUN/i686-elf-g++"
 
 COMMON_PARAMS="-ffreestanding -O2 -Wall -Wextra -D DEBUG"
 GCC_PARAMS="-std=gnu99 $COMMON_PARAMS"

--- a/src/drivers/io/terminal.c
+++ b/src/drivers/io/terminal.c
@@ -10,15 +10,16 @@ size_t activeRow;
 size_t activeColumn;
 bool lineBroken;
 
-void term_enable_cursor(void) {
-    outb(0x3D4, 0x0A);
-    char curstart = inb(0x3D5) & 0x1F; // get cursor scanline start
-    outb(0x3D4, 0x0A);
-    outb(0x3D5, curstart & ~0x20);
-    outb(0x3D4, 0x0A);   // set the cursor start line to 14 and enable cursor visibility
-    outb(0x3D5, 0x0D);
-    outb(0x3D4, 0x0B);   // set the cursor end line to 15
-    outb(0x3D5, 0x0E);
+void term_enable_cursor(void)
+{
+	outb(0x3D4, 0x0A);
+	char curstart = inb(0x3D5) & 0x1F; // get cursor scanline start
+	outb(0x3D4, 0x0A);
+	outb(0x3D5, curstart & ~0x20);
+	outb(0x3D4, 0x0A);   // set the cursor start line to 14 and enable cursor visibility
+	outb(0x3D5, 0x0D);
+	outb(0x3D4, 0x0B);   // set the cursor end line to 15
+	outb(0x3D5, 0x0E);
 }
 
 void term_init(void)

--- a/src/drivers/io/terminal.c
+++ b/src/drivers/io/terminal.c
@@ -16,9 +16,9 @@ void term_enable_cursor(void)
 	char curstart = inb(0x3D5) & 0x1F; // get cursor scanline start
 	outb(0x3D4, 0x0A);
 	outb(0x3D5, curstart & ~0x20);
-	outb(0x3D4, 0x0A);   // set the cursor start line to 14 and enable cursor visibility
+	outb(0x3D4, 0x0A);   // set the cursor start scanline to 13(0x0d) and enable cursor visibility
 	outb(0x3D5, 0x0D);
-	outb(0x3D4, 0x0B);   // set the cursor end line to 15
+	outb(0x3D4, 0x0B);   // set the cursor end scanline to 14(0x0e)
 	outb(0x3D5, 0x0E);
 }
 

--- a/src/drivers/io/terminal.c
+++ b/src/drivers/io/terminal.c
@@ -10,12 +10,24 @@ size_t activeRow;
 size_t activeColumn;
 bool lineBroken;
 
+void term_enable_cursor(void) {
+    outb(0x3D4, 0x0A);
+    char curstart = inb(0x3D5) & 0x1F; // get cursor scanline start
+    outb(0x3D4, 0x0A);
+    outb(0x3D5, curstart & ~0x20);
+    outb(0x3D4, 0x0A);   // set the cursor start line to 14 and enable cursor visibility
+    outb(0x3D5, 0x0D);
+    outb(0x3D4, 0x0B);   // set the cursor end line to 15
+    outb(0x3D5, 0x0E);
+}
+
 void term_init(void)
 {
-    vgaBuffer = (uint16_t*)0xB8000;
+	vgaBuffer = (uint16_t*)0xB8000;
 	activeColor = vga_entry_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
 
 	term_clear();
+	term_enable_cursor();
 	term_writeline("Terminal initialized.", false);
 }
 


### PR DESCRIPTION
Add code to enable the cursor and to set the scan lines to line 13 and 14 to make the cursor appear as an underline. Fix issue with GRUB not enabling and setting cursor shape when grub.cfg uses timeout of 0.